### PR TITLE
Road trip

### DIFF
--- a/app/controllers/api/v1/road_trip_controller.rb
+++ b/app/controllers/api/v1/road_trip_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::RoadTripController < ApplicationController
+
+  def create
+    user = User.find_by(api_key: params[:api_key])
+    if user
+      roadtrip
+    else
+      failed
+    end
+  end
+
+private
+
+  def roadtrip
+    render json: RoadtripSerializer.new(RoadtripFacade.new(params[:origin], params[:destination]))
+  end
+
+  def failed
+    render json: { failed: 'Unauthorized' }, status: 401
+  end
+end

--- a/app/facades/roadtrip_facade.rb
+++ b/app/facades/roadtrip_facade.rb
@@ -1,0 +1,39 @@
+class RoadtripFacade
+  attr_reader :id, :origin, :destination
+
+  def initialize(origin, destination)
+    @id = nil
+    @origin = origin
+    @destination = destination
+    @google_service = GoogleService.new(@origin).directions(@destination)
+    @open_weather_service = OpenWeatherService.new(destination_lat_long).forecast_data
+  end
+
+  def travel_time
+    @google_service[:duration][:text]
+  end
+
+  def arrival_forecast
+    future_index = travel_time_rounded + 1
+    future_forecast = @open_weather_service.first[:hourly][future_index]
+    {
+      temp: future_forecast[:temp],
+      summary: future_forecast[:weather][0][:description]
+    }
+  end
+
+  private
+
+    def destination_lat_long
+      @google_service[:end_location]
+    end
+
+    def travel_time_rounded
+      minutes = (@google_service[:duration][:value] / 60).to_f
+      (minutes / 60).round
+    end
+    #
+    # def arrival_time_hour
+    #    arrival_time = Time.now.to_i + travel_time_in_seconds
+    # end
+end

--- a/app/serializers/roadtrip_serializer.rb
+++ b/app/serializers/roadtrip_serializer.rb
@@ -1,0 +1,5 @@
+class RoadtripSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :origin, :destination, :travel_time, :arrival_forecast
+end

--- a/app/services/google_service.rb
+++ b/app/services/google_service.rb
@@ -4,6 +4,14 @@ class GoogleService
     @location = location
   end
 
+  def directions(destination)
+    response = conn.get('maps/api/directions/json') do |req|
+      req.params['destination'] = destination
+      req.params['origin'] = @location
+    end
+    JSON.parse(response.body, symbolize_names: true)[:routes][0][:legs][0]
+  end
+
   def geocode_data
     response = conn.get('maps/api/geocode/json') do |req|
       req.params['address'] = @location

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get '/backgrounds', to: 'background#show'
       post '/users', to: 'users#create'
       post '/sessions', to: 'sessions#create'
+      post '/road_trip', to: 'road_trip#create'
     end
   end
 end

--- a/spec/api/v1/endpoints/roadtrip_spec.rb
+++ b/spec/api/v1/endpoints/roadtrip_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe 'I can create a road trip', :type => :request do
+  it 'can take in road trip info and return travel time and arrival forecast' do
+    user = User.create({
+      email: "test@example.com",
+      password: "password",
+      password_confirmation: "password"
+    })
+
+    post '/api/v1/road_trip', params: {
+        origin: "Denver,CO",
+        destination: "Pueblo,CO",
+        api_key: user.api_key
+      }.to_json, headers: {
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/json'
+      }
+
+    expect(response).to be_successful
+    road_trip = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+
+    expect(road_trip.keys).to eq([:origin, :destination, :travel_time, :arrival_forecast])
+    expect(road_trip[:origin]).not_to be_empty
+    expect(road_trip[:origin]).to be_a String
+    expect(road_trip[:destination]).not_to be_empty
+    expect(road_trip[:destination]).to be_a String
+    expect(road_trip[:travel_time]).not_to be_empty
+    expect(road_trip[:travel_time]).to be_a String
+    expect(road_trip[:arrival_forecast].keys).to eq([:temp, :summary])
+    expect(road_trip[:arrival_forecast][:temp]).to be_a Float
+    expect(road_trip[:arrival_forecast][:summary]).not_to be_empty
+    expect(road_trip[:arrival_forecast][:summary]).to be_a String
+  end
+
+  it 'will not take in road trip info without a valid API key' do
+    post '/api/v1/road_trip', params: {
+        origin: "Denver,CO",
+        destination: "Pueblo,CO"
+      }.to_json, headers: {
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/json'
+      }
+
+    expect(response).to_not be_successful
+    road_trip = JSON.parse(response.body, symbolize_names: true)
+
+    expect(road_trip[:failed]).to eq('Unauthorized')
+  end
+end


### PR DESCRIPTION
## Description

- Roadtrip functionality complete: 

- Robust test that a roadtrip is returning all of the attributes from the wireframe including sad path if credentials are bad. 
- The facade is making calls to both the google service and open weather service to see how long it takes to drive between origin and destination, then plugging in the coordinates for the destination to see the weather forecast. 
- The crux of this problem for me was figuring out the forecast upon arrival to the destination, which I think I solved in a relatively simple way with the arrival forecast method in the facade. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## RSpec Results
```
Finished in 1.03 seconds (files took 3.57 seconds to load)
15 examples, 0 failures

Coverage report generated for RSpec to /Users/davidholtkamp521/turing/3module/projects/sweater_weather/coverage. 196 / 198 LOC (98.99%) covered.
```
